### PR TITLE
Update to not look at the coding for SMART auth URIs.

### DIFF
--- a/lib/smart.js
+++ b/lib/smart.js
@@ -25,30 +25,24 @@ function authFromCapability(capabilityStatement) {
 
   try {
     capabilityStatement.rest.forEach((restItem) => {
-      restItem.security.service.forEach((serviceItem) => {
-        serviceItem.coding.forEach((codingItem) => {
-          if (codingItem.code === 'SMART-on-FHIR') {
-            const uris = restItem.security.extension.find(x => x.url === smartOauthUrl);
+      const uris = restItem.security.extension.find(x => x.url === smartOauthUrl);
 
-            uris.extension.forEach((ext) => {
-              switch (ext.url) {
-                case 'authorize':
-                  authMetadata.authorizeUrl = new URL(ext.valueUri);
-                  break;
-                case 'token':
-                  authMetadata.tokenUrl = new URL(ext.valueUri);
-                  break;
-                case 'register':
-                  authMetadata.registerUrl = new URL(ext.valueUri);
-                  break;
-                case 'manage':
-                  authMetadata.manageUrl = new URL(ext.valueUri);
-                  break;
-                default:
-              }
-            });
-          }
-        });
+      uris.extension.forEach((ext) => {
+        switch (ext.url) {
+          case 'authorize':
+            authMetadata.authorizeUrl = new URL(ext.valueUri);
+            break;
+          case 'token':
+            authMetadata.tokenUrl = new URL(ext.valueUri);
+            break;
+          case 'register':
+            authMetadata.registerUrl = new URL(ext.valueUri);
+            break;
+          case 'manage':
+            authMetadata.manageUrl = new URL(ext.valueUri);
+            break;
+          default:
+        }
       });
     });
     return authMetadata;


### PR DESCRIPTION
It seems like this has simplified, so this patch does not try to look at the coding.

* http://launch.smarthealthit.org/v/r3/fhir/metadata
* http://launch.smarthealthit.org/v/r2/fhir/metadata