### PR TITLE
Transaction body unwrap

### DIFF
--- a/docs/fhir-kit-client/0.3.1/client.js.html
+++ b/docs/fhir-kit-client/0.3.1/client.js.html
@@ -475,13 +475,12 @@ class Client {
    * let response = await fhirClient.transaction(requestBundle);
    * console.log(response);
    *
-   * @param {Object} params - The request parameters.
-   * @param {String} params.body - The request body with a type of 'transaction'.
+   * @param {Object} params - The request body with a type of 'transaction'.
    *
    * @return {Promise&lt;Object>} FHIR resources in a FHIR Bundle structure.
    */
-  transaction({ body } = {}) {
-    return this.httpClient.post('/', body);
+  transaction(params = {}) {
+    return this.httpClient.post('/', params);
   }
 
   /**

--- a/docs/fhir-kit-client/0.3.1/module-fhir-kit-client-Client.html
+++ b/docs/fhir-kit-client/0.3.1/module-fhir-kit-client-Client.html
@@ -879,7 +879,7 @@ The resourceType and id must be specified.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line587">line 587</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line586">line 586</a>
     </li></ul></dd>
     
 
@@ -1705,7 +1705,7 @@ console.log(response);</code></pre>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line623">line 623</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line622">line 622</a>
     </li></ul></dd>
     
 
@@ -1978,7 +1978,7 @@ console.log(response);</code></pre>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line453">line 453</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line452">line 452</a>
     </li></ul></dd>
     
 
@@ -2427,7 +2427,7 @@ console.log(response);</code></pre>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line464">line 464</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line463">line 463</a>
     </li></ul></dd>
     
 
@@ -3075,7 +3075,7 @@ client.resolve('#patient-1' someResource).then((patient) => {
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line651">line 651</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line650">line 650</a>
     </li></ul></dd>
     
 
@@ -3325,7 +3325,7 @@ console.log(response);</code></pre>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line530">line 530</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line529">line 529</a>
     </li></ul></dd>
     
 
@@ -3580,7 +3580,7 @@ console.log(response);</code></pre>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line496">line 496</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line495">line 495</a>
     </li></ul></dd>
     
 
@@ -4018,7 +4018,7 @@ console.log(response);</code></pre>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line692">line 692</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line691">line 691</a>
     </li></ul></dd>
     
 
@@ -4140,7 +4140,7 @@ Only the parameters defined for all resources can be used.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line555">line 555</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line554">line 554</a>
     </li></ul></dd>
     
 
@@ -4371,7 +4371,7 @@ The transaction fails if any resource overlap in DELETE, POST and PUT.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line442">line 442</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line441">line 441</a>
     </li></ul></dd>
     
 
@@ -4432,58 +4432,7 @@ The transaction fails if any resource overlap in DELETE, POST and PUT.</p>
             
 
             <td class="description last">
-                <p>The request parameters.</p>
-                
-                    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>body</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type"><code>String</code></span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last">
                 <p>The request body with a type of 'transaction'.</p>
-                
-            </td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
                 
             </td>
         </tr>
@@ -4626,7 +4575,7 @@ console.log(response);</code></pre>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="client.js.html">client.js</a>, <a href="client.js.html#line673">line 673</a>
+        <a href="client.js.html">client.js</a>, <a href="client.js.html#line672">line 672</a>
     </li></ul></dd>
     
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -434,13 +434,12 @@ class Client {
    * let response = await fhirClient.transaction(requestBundle);
    * console.log(response);
    *
-   * @param {Object} params - The request parameters.
-   * @param {String} params.body - The request body with a type of 'transaction'.
+   * @param {Object} params - The request body with a type of 'transaction'.
    *
    * @return {Promise<Object>} FHIR resources in a FHIR Bundle structure.
    */
-  transaction({ body } = {}) {
-    return this.httpClient.post('/', body);
+  transaction(params = {}) {
+    return this.httpClient.post('/', params);
   }
 
   /**

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -729,7 +729,7 @@ describe('Client', function () {
           .reply(200, () => readStreamFor('transaction-results.json'));
 
         const body = readFixture('transaction-request.json');
-        const response = await this.fhirClient.transaction({ body });
+        const response = await this.fhirClient.transaction(body);
 
         expect(response.resourceType).to.equal('Bundle');
         expect(response.type).to.equal('transaction-response');
@@ -750,7 +750,7 @@ describe('Client', function () {
 
         let response;
         try {
-          response = await this.fhirClient.transaction({ body });
+          response = await this.fhirClient.transaction(body);
         } catch (error) {
           expect(error.response.status).to.equal(404);
           expect(error.response.data.resourceType).to.equal('OperationOutcome');


### PR DESCRIPTION
Unwraps the transaction parameters from the `body` property, as the [documentation examples](https://vermonster.github.io/fhir-kit-client/fhir-kit-client/0.3.1/module-fhir-kit-client-Client.html#transaction) show.

Before:

```javascript
const requestBundle = {
  'resourceType': 'Bundle',
  'type': 'transaction',
  'entry': [
    ...
  ]
}

fhirClient.transaction({
  body: requestBundle
});
```

After:

```javascript
const requestBundle = {
  'resourceType': 'Bundle',
  'type': 'transaction',
  'entry': [
    ...
  ]
}

fhirClient.transaction(requestBundle);
```
