### PR TITLE
Enforce presence of baseUrl

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,6 +13,7 @@ class Client {
    *
    * @param {Object} config Client configuration
    * @param {String} config.baseUrl ISS for FHIR server
+   * @throws An error will be thrown unless baseUrl is a non-empty string.
    */
   constructor({ baseUrl } = {}) {
     this.httpClient = new HttpClient({ baseUrl });
@@ -27,15 +28,23 @@ class Client {
    * @return {String} - Get the baseUrl
    */
   get baseUrl() {
-    return this.httpClient.baseURL;
+    return this.httpClient.baseUrl;
   }
 
   /**
    * Set the baseUrl.
    *
    * @param {String} url - Set the baseUrl
+   * @throws An error will be thrown unless baseUrl is a non-empty string.
    */
   set baseUrl(url) {
+    if (!url) {
+      throw new Error('baseUrl cannot be blank');
+    }
+    if (typeof url !== 'string') {
+      throw new Error('baseUrl must be a string');
+    }
+
     this.httpClient.baseURL = url;
   }
 
@@ -71,13 +80,13 @@ class Client {
    *
    * // Try to resolve a patient in the bundle, otherwise build request
    * // at client.baseUrl
-   * client.resolve('Patient/1' bundle).then((patient) => {
+   * client.resolve('Patient/1', bundle).then((patient) => {
    *   console.log(patient);
    * });
    *
    * // Resolve a patient contained in someResource (see:
    * // http://hl7.org/fhir/STU3/references.html#contained)
-   * client.resolve('#patient-1' someResource).then((patient) => {
+   * client.resolve('#patient-1', someResource).then((patient) => {
    *   console.log(patient);
    * });
    *

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -108,6 +108,6 @@ module.exports = class {
   }
 
   mergeHeaders(customHeaders) {
-    return Object.assign({}, defaultHeaders, this.authHeader, this.acceptHeader, customHeaders);
+    return Object.assign({}, defaultHeaders, this.authHeader, customHeaders);
   }
 };

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -82,8 +82,13 @@ describe('Client', function () {
     this.fhirClient = new Client(config);
   });
 
-  it('initializes without config', function () {
-    expect(new Client()).to.exist;
+  it('throws an error if baseUrl is blank', function () {
+    expect(() => new Client()).to.throw('baseUrl cannot be blank');
+    expect(() => { this.fhirClient.baseUrl = ''; }).to.throw('baseUrl cannot be blank');
+  });
+
+  it('throws an error if baseUrl is not a string', function () {
+    expect(() => new Client({ baseUrl: 1 })).to.throw('baseUrl must be a string');
   });
 
   it('initializes with config', function () {


### PR DESCRIPTION
This PR addresses #73. If `baseUrl` is not present, uninformative errors such as the following can be thrown:
```
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'endsWith' of undefined
    at module.exports.expandUrl (fhir-kit-client/lib/http-client.js:101:22)
```
This branch throws a more informative error when `baseUrl` is blank or not a string, so users of the library can more easily determine the real problem. It also makes some very minor fixes that I noticed while working on this branch.

This is a breaking change since a client can no longer be instantiated without a `baseUrl`. I don't see any real uses for that, though, so I think this change is worth making.