### PR TITLE
Add POST search

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -791,7 +791,11 @@ class Client {
       throw error;
     }
 
-    const searchPath = `/${compartmentType}/${compartmentId}/${resourceType}`;
+    let searchPath = `/${compartmentType}/${compartmentId}/${resourceType}`;
+
+    if (options.postSearch) {
+      searchPath += '/_search';
+    }
 
     return this.baseSearch({ searchPath, searchParams, headers, options });
   }
@@ -817,10 +821,10 @@ class Client {
    */
   baseSearch({ searchPath, searchParams, headers, options }) {
     const searchQuery = createQueryString(searchParams);
-    const searchHeaders = deprecateHeaders(options, headers);
+    const searchOptions = deprecateHeaders(options, headers);
     const searchFunction = options.postSearch ? 'postSearch' : 'getSearch';
 
-    return this[searchFunction](searchPath, searchQuery, searchHeaders);
+    return this[searchFunction](searchPath, searchQuery, searchOptions);
   }
 
   /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,8 +1,8 @@
-const queryString = require('query-string');
 const { authFromCapability } = require('./smart');
 const HttpClient = require('./http-client');
 const ReferenceResolver = require('./reference-resolver');
 const Pagination = require('./pagination');
+const { createQueryString } = require('./utils');
 const { deprecatePaginationArgs, deprecateHeaders } = require('./deprecations');
 
 /**
@@ -635,8 +635,11 @@ class Client {
    * @param {Object} [params.options] - Optional options object
    * @param {Object} [params.options.headers] - Optional headers to add to the
    *   request
+   * @param {Boolean} [params.options.postSearch] - if true, all `searchParams`
+   *   will be placed in the request body rather than the url, and the search
+   *   will use POST rather than GET
    *
-   * @return {Promise<Object>} FHIR resources in a FHIR Bundle structure.
+   * @return {Promise<Object>} FHIR resources in a Bundle
    *
    * @throws {Error} if neither searchParams nor resourceType are supplied
    */
@@ -691,16 +694,20 @@ class Client {
    * @param {Object} [params.options] - Optional options object
    * @param {Object} [params.options.headers] - Optional headers to add to the
    *   request
+   * @param {Boolean} [params.options.postSearch] - if true, all `searchParams`
+   *   will be placed in the request body rather than the url, and the search
+   *   will use POST rather than GET
    *
-   * @return {Promise<Object>} FHIR resources in a FHIR Bundle structure.
+   * @return {Promise<Object>} FHIR resources in a Bundle
    */
   resourceSearch({ resourceType, searchParams, headers, options = {} } = {}) {
     let searchPath = resourceType;
-    if (searchParams instanceof Object && Object.keys(searchParams).length > 0) {
-      searchPath += `?${queryString.stringify(searchParams)}`;
+
+    if (options.postSearch) {
+      searchPath += '/_search';
     }
 
-    return this.httpClient.get(searchPath, deprecateHeaders(options, headers));
+    return this.baseSearch({ searchPath, searchParams, headers, options });
   }
 
   /**
@@ -725,14 +732,16 @@ class Client {
    * @param {Object} [params.options] - Optional options object
    * @param {Object} [params.options.headers] - Optional headers to add to the
    *   request
+   * @param {Boolean} [params.options.postSearch] - if true, all `searchParams`
+   *   will be placed in the request body rather than the url, and the search
+   *   will use POST rather than GET
    *
-   * @return {Promise<Object>} FHIR resources in a FHIR Bundle structure.
+   * @return {Promise<Object>} FHIR resources in a Bundle
    */
   systemSearch({ searchParams, headers, options = {} } = {}) {
-    return this.httpClient.get(
-      `/_search?${queryString.stringify(searchParams)}`,
-      deprecateHeaders(options, headers),
-    );
+    const searchPath = '/_search';
+
+    return this.baseSearch({ searchPath, searchParams, headers, options });
   }
 
   /**
@@ -766,8 +775,11 @@ class Client {
    * @param {Object} [params.options] - Optional options object
    * @param {Object} [params.options.headers] - Optional headers to add to the
    *   request
+   * @param {Boolean} [params.options.postSearch] - if true, all `searchParams`
+   *   will be placed in the request body rather than the url, and the search
+   *   will use POST rather than GET
    *
-   * @return {Promise<Object>} FHIR resources in a FHIR Bundle structure.
+   * @return {Promise<Object>} FHIR resources in a Bundle
    */
   compartmentSearch({ resourceType, compartment, searchParams, headers, options = {} } = {}) {
     let compartmentType;
@@ -779,10 +791,81 @@ class Client {
       throw error;
     }
 
-    const relativePath = `/${compartmentType}/${compartmentId}/${resourceType}`;
-    const relativePathWithQuery = searchParams ? `${relativePath}?${queryString.stringify(searchParams)}` : relativePath;
+    const searchPath = `/${compartmentType}/${compartmentId}/${resourceType}`;
 
-    return this.httpClient.get(relativePathWithQuery, deprecateHeaders(options, headers));
+    return this.baseSearch({ searchPath, searchParams, headers, options });
+  }
+
+  /**
+   * Perform a search
+   *
+   * @private
+   *
+   * @param {Object} params - The request parameters.
+   * @param {String} params.searchPath - The url path
+   * @param {Object} [params.searchParams] - The search parameters, optional
+   * @param {Object} [params.headers] - DEPRECATED Optional custom headers to
+   *   add to the request
+   * @param {Object} [params.options] - Optional options object
+   * @param {Object} [params.options.headers] - Optional headers to add to the
+   *   request
+   * @param {Boolean} [params.options.postSearch] - if true, all `searchParams`
+   *   will be placed in the request body rather than the url, and the search
+   *   will use POST rather than GET
+   *
+   * @return {Promise<Object>} FHIR resources in a FHIR Bundle
+   */
+  baseSearch({ searchPath, searchParams, headers, options }) {
+    const searchQuery = createQueryString(searchParams);
+    const searchHeaders = deprecateHeaders(options, headers);
+    const searchFunction = options.postSearch ? 'postSearch' : 'getSearch';
+
+    return this[searchFunction](searchPath, searchQuery, searchHeaders);
+  }
+
+  /**
+   * Perform a search using POST
+   *
+   * @private
+   *
+   * @param {String} path - The url path
+   * @param {String} [query] - The query string, optional
+   * @param {Object} [params.headers] - DEPRECATED Optional custom headers to
+   *   add to the request
+   * @param {Object} [options] - Optional options object
+   * @param {Object} [options.headers] - Optional headers to add to the
+   *   request
+   *
+   * @return {Promise<Object>} FHIR resources in a FHIR Bundle
+   */
+  postSearch(path, query, options) {
+    const defaultHeader = { 'Content-Type': 'application/x-www-form-urlencoded' };
+    const postHeaders = { ...defaultHeader, ...options.headers };
+    const postOptions = { ...options, headers: postHeaders };
+
+    return this.httpClient.post(path, query, postOptions);
+  }
+
+  /**
+   * Perform a search using GET
+   *
+   * @private
+   *
+   * @param {String} path - The url path
+   * @param {String} [query] - The query string, optional
+   * @param {Object} [options] - Optional options object
+   * @param {Object} [options.headers] - Optional headers to add to the
+   *   request
+   *
+   * @return {Promise<Object>} FHIR resources in a FHIR Bundle
+   */
+  getSearch(path, query, options) {
+    let searchPath = path;
+    if (query) {
+      searchPath += `?${query}`;
+    }
+
+    return this.httpClient.get(searchPath, options);
   }
 
   /**

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -20,6 +20,9 @@ function responseError({
   } catch (e) {
     data = rawData;
   }
+  if (!error.response) {
+    error.response = {};
+  }
   error.response.status = status;
   error.response.data = data;
   error.config = { method: httpVerb, url, headers };
@@ -27,6 +30,13 @@ function responseError({
   return error;
 }
 /* eslint-enable no-param-reassign */
+
+function stringifyBody(body) {
+  if (typeof body === 'string') {
+    return body;
+  }
+  return JSON.stringify(body);
+}
 
 /**
  * Class used by Client to make HTTP requests. Do not use this class directly,
@@ -65,7 +75,7 @@ module.exports = class {
       uri: fullUrl,
       headers,
       method: httpVerb,
-      body: JSON.stringify(body),
+      body: stringifyBody(body),
       forever: true,
       resolveWithFullResponse: true,
     };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const { fhirReferenceRegEx } = require('./fhir-regular-expressions');
+const queryString = require('query-string');
 
 /**
  * Split a FHIR reference into its baseUrl (if present), type, and id
@@ -39,6 +40,13 @@ function splitReference(reference) {
   };
 }
 
+function createQueryString(queryParams) {
+  if (queryParams instanceof Object && Object.keys(queryParams).length > 0) {
+    return queryString.stringify(queryParams);
+  }
+}
+
 module.exports = {
+  createQueryString,
   splitReference,
 };

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -555,6 +555,23 @@ describe('Client', function () {
         expect(response.id).to.equal('95a2de95-08c7-418e-b4d0-2dd6fc8cc37e');
       });
 
+      it('performs a POST search', async function () {
+        nock(this.baseUrl)
+          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('content-type', 'application/x-www-form-urlencoded')
+          .post('/Patient/_search', 'name=abbott')
+          .reply(200, () => readStreamFor('search-results.json'));
+
+        const response = await this.fhirClient.resourceSearch({
+          resourceType: 'Patient',
+          searchParams: { name: 'abbott' },
+          options: { postSearch: true },
+        });
+
+        expect(response.resourceType).to.equal('Bundle');
+        expect(response.id).to.equal('95a2de95-08c7-418e-b4d0-2dd6fc8cc37e');
+      });
+
       it('supports repeated query params', async function () {
         nock(this.baseUrl)
           .matchHeader('accept', 'application/json+fhir')
@@ -629,6 +646,22 @@ describe('Client', function () {
         expect(response.id).to.equal('95a2de95-08c7-418e-b4d0-2dd6fc8cc37e');
       });
 
+      it('performs a POST search', async function () {
+        nock(this.baseUrl)
+          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('content-type', 'application/x-www-form-urlencoded')
+          .post('/_search', 'name=abcdef')
+          .reply(200, () => readStreamFor('system-search-results.json'));
+
+        const response = await this.fhirClient.systemSearch({
+          searchParams: { name: 'abcdef' },
+          options: { postSearch: true },
+        });
+
+        expect(response.resourceType).to.equal('Bundle');
+        expect(response.id).to.equal('95a2de95-08c7-418e-b4d0-2dd6fc8cc37e');
+      });
+
       it('supports repeated query params', async function () {
         nock(this.baseUrl)
           .matchHeader('accept', 'application/json+fhir')
@@ -684,6 +717,25 @@ describe('Client', function () {
           compartment: { resourceType: 'Patient', id: 385800201 },
           resourceType: 'Condition',
           searchParams: { category: 'problem' },
+        });
+
+        expect(response.resourceType).to.equal('Bundle');
+        expect(response.type).to.equal('searchset');
+        expect(response.total).to.equal(6);
+      });
+
+      it('performs a POST search', async function () {
+        nock(this.baseUrl)
+          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('content-type', 'application/x-www-form-urlencoded')
+          .post('/Patient/385800201/Condition/_search', 'category=problem')
+          .reply(200, () => readStreamFor('compartment-search-with-query-results.json'));
+
+        const response = await this.fhirClient.compartmentSearch({
+          compartment: { resourceType: 'Patient', id: 385800201 },
+          resourceType: 'Condition',
+          searchParams: { category: 'problem' },
+          options: { postSearch: true },
         });
 
         expect(response.resourceType).to.equal('Bundle');


### PR DESCRIPTION
Addresses #94 

This branch adds support for performing a search with POST rather than GET. To do this, pass the `postSearch` option:
```
client.search({
  resourceType: 'Patient',
  searchParams: { name: 'Steve' },
  options: { postSearch: true },
});
```