### PR TITLE
Add a mechanism to pass back HTTP header for CRUD operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Node FHIR client library
 * Modern ES6 Classes
 * TDD with Mocha
 * URL polyfill (so it works in client-only apps without much trouble)
+* Support servers that enforce return=minimal on REST CREATE and UPDATE CRUD operations
 
 ## Examples
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -288,6 +288,22 @@ class Client {
    *   body: newPatient,
    * })
    * console.log(response);
+   * // Note the client returns the HTTP headers of the CREATE operation
+   * // response, if the server doesn't support return=representation mode for REST
+   *
+   * // Additionally, the response object is augmented with non-enumerable additional
+   * // meta-data, so HTTP headers, HTTP status code and the object location on the FHIR
+   * // server are always available, so the outcome of conditional operations can be detected.
+   *
+   * // See http://hl7.org/fhir/STU3/http.html#2.21.0.5.2
+   *
+   * const Client = require('fhir-kit-client');
+   *
+   * // ... perform a create
+   *
+   * console.log(response[Client.Headers]); // HTTP headers returned by the server
+   * console.log(response[Client.Location]); // URI of the created resource
+   * console.log(response[Client.StatusCode]); // HTTP status code from server
    *
    * @param {Object} params - The request parameters.
    * @param {String} params.resourceType - The FHIR resource type.
@@ -298,7 +314,7 @@ class Client {
    * @param {Object} [params.options.headers] - Optional headers to add to the
    *   request
    *
-   * @return {Promise<Object>} FHIR resource
+   * @return {Promise<Object>} FHIR resource or HTTP request headers, when no resource was returned by server
    */
   create({ resourceType, body, headers, options = {} } = {}) {
     return this.httpClient.post(resourceType, body, deprecateHeaders(options, headers));
@@ -917,4 +933,8 @@ class Client {
   }
 }
 
+Client.Headers = Symbol.for('fhir-kit-client-headers');
+Client.StatusCode = Symbol.for('fhir-kit-client-statusCode');
+Client.Location = Symbol.for('fhir-kit-client-location');
+	
 module.exports = Client;

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -5,6 +5,13 @@ const { logRequestError, logRequestInfo, logResponseInfo } = require('./logging'
 
 const defaultHeaders = { accept: 'application/json+fhir' };
 
+function assignProperty(object, value, property) {
+  Object.defineProperty(object, property, {
+    enumerable: false,
+    value,
+  });
+}
+
 /* eslint-disable no-param-reassign */
 function responseError({
   error,
@@ -72,7 +79,15 @@ module.exports = class {
     const data = await request(requestParams)
       .then((response) => {
         status = response.statusCode;
-        return JSON.parse(response.body);
+        const r = response.body ? JSON.parse(response.body) : response.headers;
+	
+        assignProperty(r, response.headers, Symbol.for('fhir-kit-client-headers'));
+        assignProperty(r, status, Symbol.for('fhir-kit-client-statusCode'));
+        if (response.headers.location) {
+          assignProperty(r, response.headers.location, Symbol.for('fhir-kit-client-location'));
+        }
+
+        return r;
       }).catch((errorResponse) => {
         status = errorResponse.statusCode;
         error = errorResponse;


### PR DESCRIPTION
This PR add a mechanism to pass back HTTP header information for CRUD operations for servers that don't support the representation mechanism for responding to CRUD operations. The Finnish Omakanta service forces the `return=minimal` mode of operation for CRUD operations, which made it necessary to patch the library for it to work against the system. The current mainline implementation of fhir-kit-client seems to assume `return=presentation` mode in these cases and fails if the response body is empty. Additionally the current mainline doesn't allow developers to check the HTTP response codes for conditional CRUD operations, which is needed for example for detecting if a conditional create returns response code 200 or 201 (as per STU3 REST spec at  http://hl7.org/fhir/STU3/http.html).

The new metadata is passed back as hidden metadata elements using non-enumerable values that use symbols for the key and thus the change is 100% backward compatible for existing implementations that use servers with `return=presentation` CRUD operation outcome mode.