### PR TITLE
Fix null pointer exception

### DIFF
--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -21,7 +21,7 @@ function responseError({
     data = rawData;
   }
   if (error.response === undefined) {
-     error.response = {} 
+    error.response = {};
   }
   error.response.status = status;
   error.response.data = data;

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -20,6 +20,9 @@ function responseError({
   } catch (e) {
     data = rawData;
   }
+  if (error.response === undefined) {
+     error.response = {} 
+  }
   error.response.status = status;
   error.response.data = data;
   error.config = { method: httpVerb, url, headers };

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -20,9 +20,7 @@ function responseError({
   } catch (e) {
     data = rawData;
   }
-  if (error.response === undefined) {
-    error.response = {};
-  }
+  error.response = error.response || {};
   error.response.status = status;
   error.response.data = data;
   error.config = { method: httpVerb, url, headers };

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -96,6 +96,17 @@ describe('Client', function () {
     expect(this.fhirClient.pagination).to.be.an.instanceof(Pagination);
   });
 
+  it('throws correct error with request error', async function () {
+    nock(this.baseUrl)
+      .get('/Basic/1')
+      .replyWithError('cannot connect');
+    return this.fhirClient.read({
+      resourceType: 'Basic',
+      id: '1',
+    }).then(() => { throw new Error('should not have succeeded'); })
+      .catch((error) => { expect(error).to.have.property('message', 'Error: cannot connect'); });
+  });
+
   describe('#smartAuthMetadata', function () {
     it('builds a request with custom headers', async function () {
       nock(this.baseUrl)


### PR DESCRIPTION
When a non HTTP related error occurs (like a connection error), the library throws an unknown error because of being unable to set the status field on the response.  This corrects the behavior.