### PR TITLE
Fix responseFor() documentation to use correct method name

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -60,7 +60,7 @@ class Client {
    *   resourceType: 'Patient',
    *   id: 12345,
    * }).then((data) => {
-   *   const response = Client.requestFor(data);
+   *   const response = Client.responseFor(data);
    *   console.log(response.headers);
    * });
    *


### PR DESCRIPTION
Sorry for not noticing this earlier - in the 1.3 release, the new `Client.responseFor()` API call is documented as `Client.requestFor()`