### PR TITLE
adapt code to work with iOS JavaScript engine...

### DIFF
--- a/lib/deprecations.js
+++ b/lib/deprecations.js
@@ -14,7 +14,7 @@ const deprecatePaginationArgs = (results, headers) => {
 const deprecateHeaders = (options, headers) => {
   if (headers) {
     console.warn('WARNING: headers is deprecated and will be removed in the next major version. Use options.headers instead.');
-    console.dir(headers);
+    console.warn(JSON.stringify(headers, null, '  '));
     return { headers, ...options };
   }
   return options;


### PR DESCRIPTION
~test for~ Replace  `console.dir`, b/c `console.dir` does not seem available to the iOS JavaScript execution engine in production builds.

