### PR TITLE
name.family should be string, not an array

### DIFF
--- a/docs/fhir-kit-client/1.6.3/client.js.html
+++ b/docs/fhir-kit-client/1.6.3/client.js.html
@@ -428,7 +428,7 @@ class Client {
    * const newPatient = {
    *   resourceType: 'Patient',
    *   active: true,
-   *   name: [{ use: 'official', family: ['Coleman'], given: ['Lisa', 'P.'] }],
+   *   name: [{ use: 'official', family: 'Coleman', given: ['Lisa', 'P.'] }],
    *   gender: 'female',
    *   birthDate: '1948-04-14',
    * }

--- a/docs/fhir-kit-client/1.6.3/module-fhir-kit-client-Client.html
+++ b/docs/fhir-kit-client/1.6.3/module-fhir-kit-client-Client.html
@@ -2517,7 +2517,7 @@ request</p>
     <pre class="prettyprint"><code>const newPatient = {
   resourceType: 'Patient',
   active: true,
-  name: [{ use: 'official', family: ['Coleman'], given: ['Lisa', 'P.'] }],
+  name: [{ use: 'official', family: 'Coleman', given: ['Lisa', 'P.'] }],
   gender: 'female',
   birthDate: '1948-04-14',
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -387,7 +387,7 @@ class Client {
    * const newPatient = {
    *   resourceType: 'Patient',
    *   active: true,
-   *   name: [{ use: 'official', family: ['Coleman'], given: ['Lisa', 'P.'] }],
+   *   name: [{ use: 'official', family: 'Coleman', given: ['Lisa', 'P.'] }],
    *   gender: 'female',
    *   birthDate: '1948-04-14',
    * }

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1041,7 +1041,7 @@ describe('Client', function () {
         const newPatient = {
           resourceType: 'Patient',
           active: true,
-          name: [{ use: 'official', family: ['Coleman'], given: ['Lisa', 'P.'] }],
+          name: [{ use: 'official', family: 'Coleman', given: ['Lisa', 'P.'] }],
           gender: 'female',
           birthDate: '1948-04-14',
         };
@@ -1067,7 +1067,7 @@ describe('Client', function () {
         const newPatient = {
           resourceType: 'Patient',
           active: true,
-          name: [{ use: 'official', family: ['Coleman'], given: ['Lisa', 'P.'] }],
+          name: [{ use: 'official', family: 'Coleman', given: ['Lisa', 'P.'] }],
           gender: 'female',
           birthDate: '1948-04-14',
         };
@@ -1090,7 +1090,7 @@ describe('Client', function () {
       it('throws an error if the resource is not supported', async function () {
         const newRecord = {
           resourceType: 'Foo',
-          name: [{ use: 'official', family: ['Coleman'], given: ['Lisa', 'P.'] }],
+          name: [{ use: 'official', family: 'Coleman', given: ['Lisa', 'P.'] }],
         };
 
         nock(this.baseUrl)
@@ -1118,7 +1118,7 @@ describe('Client', function () {
         const newPatient = {
           resourceType: 'Patient',
           active: true,
-          name: [{ use: 'official', family: ['Coleman'], given: ['Lisa', 'P.'] }],
+          name: [{ use: 'official', family: 'Coleman', given: ['Lisa', 'P.'] }],
           gender: 'female',
           birthDate: '1948-04-14',
         };


### PR DESCRIPTION
in the examples and tests the patient with family name Coleman is specified as an array. The family element in HumanName is 0..1, therefore it should be represented as a string. I noticed it when using it with typescript, tests run trought correct with this change.

 family: 'Coleman' instead of  family: ['Coleman']
