### PR TITLE
switch to FHIR R4 application/fhir+json

### DIFF
--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -4,7 +4,7 @@ require('cross-fetch/polyfill');
 
 const { logRequestError, logRequestInfo, logResponseInfo } = require('./logging');
 
-const defaultHeaders = { accept: 'application/json+fhir' };
+const defaultHeaders = { accept: 'application/fhir+json' };
 
 const responseAttributeKey = '__response';
 const requestAttributeKey = '__request';
@@ -208,7 +208,7 @@ module.exports = class HttpClient {
 
   async put(url, body, options = {}) {
     const headers = {
-      ...{ 'content-type': 'application/json+fhir' },
+      ...{ 'content-type': 'application/fhir+json' },
       ...HttpClient.lcKeys(options.headers),
     };
     const putOptions = { ...options, headers };
@@ -218,7 +218,7 @@ module.exports = class HttpClient {
 
   async post(url, body, options = {}) {
     const headers = {
-      ...{ 'content-type': 'application/json+fhir' },
+      ...{ 'content-type': 'application/fhir+json' },
       ...HttpClient.lcKeys(options.headers),
     };
     const postOptions = { ...options, headers };

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -22,7 +22,7 @@ const Pagination = require('../lib/pagination');
  */
 const mockAndExpectNotFound = async function (httpVerb, apiVerb) {
   const scope = nock('http://example.com')
-    .matchHeader('accept', 'application/json+fhir');
+    .matchHeader('accept', 'application/fhir+json');
 
   switch (httpVerb) {
     case 'get':
@@ -171,7 +171,7 @@ describe('Client', function () {
   describe('#capabilityStatement', function () {
     it('builds a request with custom headers', async function () {
       const scope = nock(this.baseUrl)
-        .matchHeader('accept', /.*application\/json/)
+        .matchHeader('accept', /.*application\/fhir\+json/)
         .matchHeader('abc', 'XYZ')
         .get('/metadata')
         .reply(200, () => readStreamFor('no-smart-oauth-uri-capability-statement.json'));
@@ -187,7 +187,7 @@ describe('Client', function () {
 
     it('works with the deprecated calling style', async function () {
       const scope = nock(this.baseUrl)
-        .matchHeader('accept', /.*application\/json/)
+        .matchHeader('accept', /.*application\/fhir\+json/)
         .matchHeader('abc', 'XYZ')
         .get('/metadata')
         .reply(200, () => readStreamFor('no-smart-oauth-uri-capability-statement.json'));
@@ -203,7 +203,7 @@ describe('Client', function () {
 
     it('returns a FHIR resource from the FHIR server if metadata is not present', async function () {
       const scope = nock(this.baseUrl)
-        .matchHeader('accept', /.*application\/json/)
+        .matchHeader('accept', /.*application\/fhir\+json/)
         .get('/metadata')
         .reply(200, () => readStreamFor('no-smart-oauth-uri-capability-statement.json'));
 
@@ -237,7 +237,7 @@ describe('Client', function () {
       const reference = `${resourceType}/${id}`;
       const absoluteReference = `${this.baseUrl}/${reference}`;
       nock(this.baseUrl)
-        .matchHeader('accept', 'application/json+fhir')
+        .matchHeader('accept', 'application/fhir+json')
         .matchHeader('abc', 'XYZ')
         .get(`/${reference}`)
         .reply(200, () => readStreamFor('patient.json'));
@@ -259,7 +259,7 @@ describe('Client', function () {
       const reference = `${resourceType}/${id}`;
       const absoluteReference = `${this.baseUrl}/${reference}`;
       nock(this.baseUrl)
-        .matchHeader('accept', 'application/json+fhir')
+        .matchHeader('accept', 'application/fhir+json')
         .get(`/${reference}`)
         .reply(200, () => readStreamFor('patient.json'));
 
@@ -275,7 +275,7 @@ describe('Client', function () {
       this.fhirClient.bearerToken = 'XYZ';
 
       nock(this.baseUrl)
-        .matchHeader('accept', 'application/json+fhir')
+        .matchHeader('accept', 'application/fhir+json')
         .matchHeader('Authorization', 'Bearer XYZ')
         .get('/Patient/test-access-token')
         .reply(200, () => readStreamFor('patient.json'));
@@ -288,7 +288,7 @@ describe('Client', function () {
       this.fhirClient.bearerToken = 'XYZ';
 
       nock(this.baseUrl, { badheaders: ['Authorization'] })
-        .matchHeader('accept', 'application/json+fhir')
+        .matchHeader('accept', 'application/fhir+json')
         .get('/Patient/test-access-token')
         .reply(200, () => readStreamFor('patient.json'));
 
@@ -301,7 +301,7 @@ describe('Client', function () {
       this.fhirClient.customHeaders = { abc: 'XYZ' };
 
       nock(this.baseUrl)
-        .matchHeader('accept', 'application/json+fhir')
+        .matchHeader('accept', 'application/fhir+json')
         .matchHeader('abc', 'XYZ')
         .matchHeader('def', 'UVW')
         .get('/Patient/test-access-token')
@@ -319,7 +319,7 @@ describe('Client', function () {
       this.fhirClient.customHeaders = { abc: 'XYZ' };
 
       nock(this.baseUrl)
-        .matchHeader('accept', 'application/json+fhir')
+        .matchHeader('accept', 'application/fhir+json')
         .matchHeader('abc', 'DEF')
         .get('/Patient/test-access-token')
         .reply(200, () => readStreamFor('patient.json'));
@@ -336,7 +336,7 @@ describe('Client', function () {
     describe('#request', function () {
       it('HEAD request', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .head('/Patient/123')
           .reply(200);
 
@@ -345,7 +345,7 @@ describe('Client', function () {
 
       it('GET request', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/123')
           .reply(200, () => readStreamFor('patient.json'));
 
@@ -370,7 +370,7 @@ describe('Client', function () {
 
       it('DELETE request', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .delete('/Patient/123')
           .reply(200);
 
@@ -379,7 +379,7 @@ describe('Client', function () {
 
       it('POST request', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .post('/Patient', { resourceType: 'patient' })
           .reply(200);
 
@@ -396,7 +396,7 @@ describe('Client', function () {
 
       it('builds requests with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .get('/Patient/test-access-token')
           .reply(200, () => readStreamFor('patient.json'));
@@ -416,7 +416,7 @@ describe('Client', function () {
 
       it('throws errors for a missing resource', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/abcdef')
           .reply(404, () => readStreamFor('patient-not-found.json'));
 
@@ -433,7 +433,7 @@ describe('Client', function () {
       it('handles non-json error responses', async function () {
         const errorBody = 'An error occurred';
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/abcdef')
           .reply(404, () => errorBody);
 
@@ -455,7 +455,7 @@ describe('Client', function () {
 
       it('returns a matching resource', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/eb3271e1-ae1b-4644-9332-41e32c829486/_history/1')
           .reply(200, () => readStreamFor('patient.json'));
 
@@ -471,7 +471,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .get('/Patient/eb3271e1-ae1b-4644-9332-41e32c829486/_history/1')
           .reply(200, () => readStreamFor('patient.json'));
@@ -489,7 +489,7 @@ describe('Client', function () {
 
       it('throws errors for an absent resource', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/abcdef/_history/1')
           .reply(404, () => readStreamFor('patient-not-found.json'));
 
@@ -509,7 +509,7 @@ describe('Client', function () {
 
       it('throws errors for an absent version of an existing resource', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/eb3271e1-ae1b-4644-9332-41e32c829486/_history/2')
           .reply(404, () => readStreamFor('patient-version-not-found.json'));
 
@@ -531,7 +531,7 @@ describe('Client', function () {
     describe('#operation', function () {
       it('runs system-level POST operation', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .post('/$everything')
           .reply(200);
 
@@ -540,7 +540,7 @@ describe('Client', function () {
 
       it('runs system-level GET operation', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/$everything')
           .reply(200);
 
@@ -549,7 +549,7 @@ describe('Client', function () {
 
       it('runs type-level operation', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/ConceptMap/$translate?code=preliminary&source=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fcomposition-status&system=http%3A%2F%2Fhl7.org%2Ffhir%2Fcomposition-status&target=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fv3-ActStatus')
           .reply(200);
 
@@ -570,7 +570,7 @@ describe('Client', function () {
 
       it('runs instance-level operation', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .post('/PlanDefinition/123/$apply')
           .reply(200);
 
@@ -665,7 +665,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .get('/Patient?name=abbott')
           .reply(200, () => readStreamFor('search-results.json'));
@@ -682,7 +682,7 @@ describe('Client', function () {
 
       it('returns a matching search results bundle', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient?name=abbott')
           .reply(200, () => readStreamFor('search-results.json'));
 
@@ -697,7 +697,7 @@ describe('Client', function () {
 
       it('performs a POST search', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('content-type', 'application/x-www-form-urlencoded')
           .post('/Patient/_search', 'name=abbott')
           .reply(200, () => readStreamFor('search-results.json'));
@@ -714,7 +714,7 @@ describe('Client', function () {
 
       it('supports repeated query params', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient?_include=Observation&_include=MedicationRequest')
           .reply(200, () => readStreamFor('search-results.json'));
 
@@ -729,7 +729,7 @@ describe('Client', function () {
 
       it('supports searching with no query parameters', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient')
           .times(2)
           .reply(200, () => readStreamFor('search-results.json'));
@@ -758,7 +758,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .get('/_search?name=abcdef')
           .reply(200, () => readStreamFor('system-search-results.json'));
@@ -774,7 +774,7 @@ describe('Client', function () {
 
       it('returns a matching search results bundle', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/_search?name=abcdef')
           .reply(200, () => readStreamFor('system-search-results.json'));
 
@@ -788,7 +788,7 @@ describe('Client', function () {
 
       it('performs a POST search', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('content-type', 'application/x-www-form-urlencoded')
           .post('/_search', 'name=abcdef')
           .reply(200, () => readStreamFor('system-search-results.json'));
@@ -804,7 +804,7 @@ describe('Client', function () {
 
       it('supports repeated query params', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/_search?_include=Observation&_include=MedicationRequest&name=abcdef')
           .reply(200, () => readStreamFor('system-search-results.json'));
 
@@ -831,7 +831,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .get('/Patient/385800201/Condition')
           .reply(200, () => readStreamFor('compartment-search-results.json'));
@@ -849,7 +849,7 @@ describe('Client', function () {
 
       it('returns a matching search results bundle with query params', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/385800201/Condition?category=problem')
           .reply(200, () => readStreamFor('compartment-search-with-query-results.json'));
 
@@ -866,7 +866,7 @@ describe('Client', function () {
 
       it('performs a POST search', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('content-type', 'application/x-www-form-urlencoded')
           .post('/Patient/385800201/Condition/_search', 'category=problem')
           .reply(200, () => readStreamFor('compartment-search-with-query-results.json'));
@@ -885,7 +885,7 @@ describe('Client', function () {
 
       it('supports repeated query params', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/385800201/Condition?_include=Observation&_include=MedicationRequest&category=problem')
           .reply(200, () => readStreamFor('compartment-search-with-query-results.json'));
 
@@ -905,7 +905,7 @@ describe('Client', function () {
 
       it('returns a matching search results bundle without query params', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/385800201/Condition')
           .reply(200, () => readStreamFor('compartment-search-results.json'));
 
@@ -924,7 +924,7 @@ describe('Client', function () {
       describe('#nextPage', function () {
         it('builds a request with custom headers', async function () {
           nock(this.baseUrl)
-            .matchHeader('accept', 'application/json+fhir')
+            .matchHeader('accept', 'application/fhir+json')
             .matchHeader('abc', 'XYZ')
             .get('/?_getpages=678cd733-8823-4324-88a7-51d369cf78a9&_getpagesoffset=3&_count=3&_pretty=true&_bundletype=searchset')
             .reply(200, () => readStreamFor('search-results-page-2.json'));
@@ -939,7 +939,7 @@ describe('Client', function () {
 
         it('works with deprecated calling style', async function () {
           nock(this.baseUrl)
-            .matchHeader('accept', 'application/json+fhir')
+            .matchHeader('accept', 'application/fhir+json')
             .matchHeader('abc', 'XYZ')
             .get('/?_getpages=678cd733-8823-4324-88a7-51d369cf78a9&_getpagesoffset=3&_count=3&_pretty=true&_bundletype=searchset')
             .reply(200, () => readStreamFor('search-results-page-2.json'));
@@ -952,7 +952,7 @@ describe('Client', function () {
           expect(response.link[0].url).to.equal(url);
 
           nock(this.baseUrl)
-            .matchHeader('accept', 'application/json+fhir')
+            .matchHeader('accept', 'application/fhir+json')
             .get('/?_getpages=678cd733-8823-4324-88a7-51d369cf78a9&_getpagesoffset=3&_count=3&_pretty=true&_bundletype=searchset')
             .reply(200, () => readStreamFor('search-results-page-2.json'));
 
@@ -964,7 +964,7 @@ describe('Client', function () {
 
         it('returns httpClient get for the next link', async function () {
           nock(this.baseUrl)
-            .matchHeader('accept', 'application/json+fhir')
+            .matchHeader('accept', 'application/fhir+json')
             .get('/?_getpages=678cd733-8823-4324-88a7-51d369cf78a9&_getpagesoffset=3&_count=3&_pretty=true&_bundletype=searchset')
             .reply(200, () => readStreamFor('search-results-page-2.json'));
 
@@ -985,7 +985,7 @@ describe('Client', function () {
       describe('#prevPage', function () {
         it('builds a request with custom headers', async function () {
           nock(this.baseUrl)
-            .matchHeader('accept', 'application/json+fhir')
+            .matchHeader('accept', 'application/fhir+json')
             .matchHeader('abc', 'XYZ')
             .get('/?_getpages=678cd733-8823-4324-88a7-51d369cf78a9&_getpagesoffset=0&_count=3&_pretty=true&_bundletype=searchset')
             .reply(200, () => readStreamFor('search-results-page-1.json'));
@@ -1000,7 +1000,7 @@ describe('Client', function () {
 
         it('returns httpClient get for the previous link', async function () {
           nock(this.baseUrl)
-            .matchHeader('accept', 'application/json+fhir')
+            .matchHeader('accept', 'application/fhir+json')
             .get('/?_getpages=678cd733-8823-4324-88a7-51d369cf78a9&_getpagesoffset=0&_count=3&_pretty=true&_bundletype=searchset')
             .reply(200, () => readStreamFor('search-results-page-1.json'));
 
@@ -1018,7 +1018,7 @@ describe('Client', function () {
 
         it('detects and responds to "prev" relations', async function () {
           nock(this.baseUrl)
-            .matchHeader('accept', 'application/json+fhir')
+            .matchHeader('accept', 'application/fhir+json')
             .get('/?_getpages=678cd733-8823-4324-88a7-51d369cf78a9&_getpagesoffset=0&_count=3&_pretty=true&_bundletype=searchset')
             .reply(200, () => readStreamFor('search-results-page-1.json'));
 
@@ -1047,8 +1047,8 @@ describe('Client', function () {
         };
 
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
-          .matchHeader('content-type', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
+          .matchHeader('content-type', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .post('/Patient', newPatient)
           .reply(201, () => readStreamFor('patient-created.json'));
@@ -1073,8 +1073,8 @@ describe('Client', function () {
         };
 
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
-          .matchHeader('content-type', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
+          .matchHeader('content-type', 'application/fhir+json')
           .post('/Patient', newPatient)
           .reply(201, () => readStreamFor('patient-created.json'));
 
@@ -1094,8 +1094,8 @@ describe('Client', function () {
         };
 
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
-          .matchHeader('content-type', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
+          .matchHeader('content-type', 'application/fhir+json')
           .post('/Foo', newRecord)
           .reply(400, () => readStreamFor('unknown-resource.json'));
 
@@ -1124,8 +1124,8 @@ describe('Client', function () {
         };
 
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
-          .matchHeader('content-type', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
+          .matchHeader('content-type', 'application/fhir+json')
           .post('/Patient', newPatient)
           .reply(201);
 
@@ -1134,7 +1134,7 @@ describe('Client', function () {
           body: newPatient,
           options: {
             headers: {
-              accept: 'application/json+fhir',
+              accept: 'application/fhir+json',
             },
           },
         });
@@ -1152,7 +1152,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .delete('/Patient/152746')
           .reply(200, () => readStreamFor('patient-deleted.json'));
@@ -1169,7 +1169,7 @@ describe('Client', function () {
 
       it('returns a successful operation outcome', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .delete('/Patient/152746')
           .reply(200, () => readStreamFor('patient-deleted.json'));
 
@@ -1181,7 +1181,7 @@ describe('Client', function () {
 
       it('throws an error for a missing resource', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .delete('/Patient/abcdef')
           .reply(404, () => readStreamFor('patient-not-found.json'));
 
@@ -1205,7 +1205,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .put('/Patient/152747')
           .reply(200, () => readStreamFor('patient-updated.json'));
@@ -1223,7 +1223,7 @@ describe('Client', function () {
 
       it('returns a successful operation outcome', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .put('/Patient/152747')
           .reply(200, () => readStreamFor('patient-updated.json'));
 
@@ -1235,7 +1235,7 @@ describe('Client', function () {
 
       it('throws an error for a missing resource', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .put('/Patient/abcdef')
           .reply(404, () => readStreamFor('patient-not-found.json'));
 
@@ -1259,7 +1259,7 @@ describe('Client', function () {
         const JSONPatch = [{ op: 'replace', path: '/gender', value: 'male' }];
 
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('content-type', 'application/json-patch+json')
           .matchHeader('abc', 'XYZ')
           .patch('/Patient/152747', JSONPatch)
@@ -1282,7 +1282,7 @@ describe('Client', function () {
         // Content-Type is 'application/json-patch+json'
         // http://hl7.org/fhir/STU3/http.html#patch
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('content-type', 'application/json-patch+json')
           .patch('/Patient/152747', JSONPatch)
           .reply(200, () => readStreamFor('patient-patched.json'));
@@ -1303,7 +1303,7 @@ describe('Client', function () {
         const invalidPatch = [{ op: 'replace', path: '/gender', value: 0 }];
 
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('content-type', 'application/json-patch+json')
           .patch('/Patient/152747', invalidPatch)
           .reply(500, () => readStreamFor('patient-not-patched.json'));
@@ -1330,7 +1330,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .post('/')
           .reply(200, () => readStreamFor('batch-results.json'));
@@ -1347,7 +1347,7 @@ describe('Client', function () {
 
       it('returns a matching batch response bundle', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .post('/')
           .reply(200, () => readStreamFor('batch-results.json'));
 
@@ -1367,7 +1367,7 @@ describe('Client', function () {
 
       it('returns a bundle of errors if any operations are unsuccessful', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .post('/')
           .reply(200, () => readStreamFor('batch-error-results.json'));
 
@@ -1394,7 +1394,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .post('/')
           .reply(200, () => readStreamFor('transaction-results.json'));
@@ -1411,7 +1411,7 @@ describe('Client', function () {
 
       it('returns a transaction response bundle with matching response statuses', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .post('/')
           .reply(200, () => readStreamFor('transaction-results.json'));
 
@@ -1429,7 +1429,7 @@ describe('Client', function () {
 
       it('throws an error if any operations are unsuccessful', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .post('/')
           .reply(404, () => readStreamFor('transaction-error-response.json'));
 
@@ -1512,7 +1512,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .get('/Patient/152747/_history')
           .reply(200, () => readStreamFor('resource-history.json'));
@@ -1528,7 +1528,7 @@ describe('Client', function () {
 
       it('returns a history bundle for a resource', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/152747/_history')
           .reply(200, () => readStreamFor('resource-history.json'));
 
@@ -1545,7 +1545,7 @@ describe('Client', function () {
 
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .get('/Patient/_history')
           .reply(200, () => readStreamFor('type-history.json'));
@@ -1560,7 +1560,7 @@ describe('Client', function () {
 
       it('returns a history bundle for a resource type', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/Patient/_history')
           .reply(200, () => readStreamFor('type-history.json'));
 
@@ -1573,7 +1573,7 @@ describe('Client', function () {
     describe('#systemHistory', function () {
       it('builds a request with custom headers', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .matchHeader('abc', 'XYZ')
           .get('/_history')
           .reply(200, () => readStreamFor('system-history.json'));
@@ -1587,7 +1587,7 @@ describe('Client', function () {
 
       it('returns a history bundle for all resources', async function () {
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get('/_history')
           .reply(200, () => readStreamFor('system-history.json'));
 

--- a/test/reference-resolver-test.js
+++ b/test/reference-resolver-test.js
@@ -32,7 +32,7 @@ describe('ReferenceResolver', function () {
           const reference = `${resourceType}/${id}`;
           const absoluteReference = `${this.baseUrl}/${reference}`;
           nock(this.baseUrl)
-            .matchHeader('accept', 'application/json+fhir')
+            .matchHeader('accept', 'application/fhir+json')
             .get(`/${reference}`)
             .reply(200, () => readStreamFor('patient.json'));
 
@@ -51,7 +51,7 @@ describe('ReferenceResolver', function () {
           const reference = `${resourceType}/${id}`;
           const absoluteReference = `${baseUrl}/${reference}`;
           nock(baseUrl)
-            .matchHeader('accept', 'application/json+fhir')
+            .matchHeader('accept', 'application/fhir+json')
             .get(`/${reference}`)
             .reply(200, () => readStreamFor('patient.json'));
 
@@ -69,7 +69,7 @@ describe('ReferenceResolver', function () {
         const id = 'eb3271e1-ae1b-4644-9332-41e32c829486';
         const reference = `${resourceType}/${id}`;
         nock(this.baseUrl)
-          .matchHeader('accept', 'application/json+fhir')
+          .matchHeader('accept', 'application/fhir+json')
           .get(`/${reference}`)
           .reply(200, () => readStreamFor('patient.json'));
 
@@ -151,7 +151,7 @@ describe('ReferenceResolver', function () {
             const reference = 'Patient/eb3271e1-ae1b-4644-9332-41e32c829486';
             const absoluteReference = `${this.baseUrl}/${reference}`;
             nock(this.baseUrl)
-              .matchHeader('accept', 'application/json+fhir')
+              .matchHeader('accept', 'application/fhir+json')
               .get(`/${reference}`)
               .reply(200, () => readStreamFor('patient.json'));
 
@@ -170,7 +170,7 @@ describe('ReferenceResolver', function () {
           it('requests the resource from baseUrl and returns it', async function () {
             const reference = 'Patient/eb3271e1-ae1b-4644-9332-41e32c829486';
             nock(this.baseUrl)
-              .matchHeader('accept', 'application/json+fhir')
+              .matchHeader('accept', 'application/fhir+json')
               .get(`/${reference}`)
               .reply(200, () => readStreamFor('patient.json'));
 


### PR DESCRIPTION
currently fhir-kit-client uses application/json+fhir as a mime type for http requests. according to FHIR R4 this should be [application/fhir+json](http://hl7.org/fhir/http.html#mime-type). could this be switched accordingly? 