### PR TITLE
FHIR client operation invoking via post

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -729,7 +729,7 @@ class Client {
     url.push(`${name.startsWith('$') ? name : `$${name}`}`);
 
     if (method === 'post') {
-      return this.httpClient.post(url.join(''), options, input);
+      return this.httpClient.post(url.join(''), input, options);
     }
     if (method === 'get') {
       if (input) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -547,13 +547,12 @@ describe('Client', function () {
             return requestBody;
           });
 
-        let response = await this.fhirClient.operation({ name: 'convert', method: 'post', input: patient });
-        console.log(response);
+        const response = await this.fhirClient.operation({ name: 'convert', method: 'post', input: patient });
 
         expect(response.resourceType).to.equal('Patient');
         expect(response.id).to.equal('eb3271e1-ae1b-4644-9332-41e32c829486');
       });
-      
+
       it('runs system-level GET operation', async function () {
         nock(this.baseUrl)
           .matchHeader('accept', 'application/fhir+json')

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -538,6 +538,22 @@ describe('Client', function () {
         await this.fhirClient.operation({ name: 'everything' });
       });
 
+      it('runs system-level POST operation convert with input', async function () {
+        const patient = readFixture('patient.json');
+        nock(this.baseUrl)
+          .matchHeader('accept', 'application/fhir+json')
+          .post('/$convert')
+          .reply(200, function (uri, requestBody) {
+            return requestBody;
+          });
+
+        let response = await this.fhirClient.operation({ name: 'convert', method: 'post', input: patient });
+        console.log(response);
+
+        expect(response.resourceType).to.equal('Patient');
+        expect(response.id).to.equal('eb3271e1-ae1b-4644-9332-41e32c829486');
+      });
+      
       it('runs system-level GET operation', async function () {
         nock(this.baseUrl)
           .matchHeader('accept', 'application/fhir+json')


### PR DESCRIPTION
For the FHIR.client.operation the input parameter was not added as the body but as option. This PR changes the invocation and adds a test with a mocked $convert (or better identity) function. 