### PR TITLE
Make CapabilityTool an export

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,7 @@ const Pagination = require('./pagination');
 const { createQueryString } = require('./utils');
 const { FetchQueue } = require('./fetch-queue');
 const { deprecatePaginationArgs, deprecateHeaders } = require('./deprecations');
+const CapabilityTool = require('./capability-tool');
 
 /**
  * @module fhir-kit-client
@@ -1182,3 +1183,4 @@ class Client {
 }
 
 module.exports = Client;
+module.exports.CapabilityTool = CapabilityTool;

--- a/test/capability-tool-test.js
+++ b/test/capability-tool-test.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const { expect } = require('chai');
 
-const CapabilityTool = require('../lib/capability-tool');
+const { CapabilityTool } = require('../lib/client');
 
 function readFixture(filename) {
   return JSON.parse(fs.readFileSync(path.normalize(`${__dirname}/fixtures/${filename}`, 'utf8')));


### PR DESCRIPTION
This addresses https://github.com/Vermonster/fhir-kit-client/issues/156

You can do this after this PR:

```javascript
import Client, { CapabilityTool } from 'fhir-kit-client'
``` 