### PR TITLE
support for http conditional update

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -518,6 +518,7 @@ class Client {
    * @param {String} params.resourceType - The resource type (e.g. "Patient",
    *   "Observation").
    * @param {String} params.id - The FHIR id for the resource.
+   * @param {String} params.searchParams - For a conditional update the searchParams are specified instead of the id, see https://www.hl7.org/fhir/http.html#cond-update
    * @param {String} params.body - The resource to be updated.
    * @param {Object} [params.headers] - DEPRECATED Optional custom headers to
    *   add to the request
@@ -527,11 +528,21 @@ class Client {
    *
    * @return {Promise<Object>} FHIR resource
    */
-  update({ resourceType, id, body, headers, options = {} } = {}) {
+  update({ resourceType, id, searchParams, body, headers, options = {} } = {}) {
     if (!validResourceType(resourceType)) {
       throw new Error('Invalid resourceType', resourceType);
     }
-
+    if (id && searchParams) {
+      throw new Error('Conditional update with search params cannot be with id', resourceType);
+    }
+    if (searchParams) {
+      const searchQuery = createQueryString(searchParams);
+      return this.httpClient.put(
+        `${resourceType}?${searchQuery}`,
+        body,
+        deprecateHeaders(options, headers),
+      );
+    }
     return this.httpClient.put(
       `${resourceType}/${id}`,
       body,

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1248,6 +1248,19 @@ describe('Client', function () {
         expect(response.issue[0].diagnostics).to.have.string('_history/2');
       });
 
+      it('returns a successful operation outcome for a conditional update', async function () {
+        nock(this.baseUrl)
+          .matchHeader('accept', 'application/fhir+json')
+          .put('/Patient?identifier=urn:1.2.3|152747')
+          .reply(200, () => readStreamFor('patient-updated.json'));
+
+        const response = await this.fhirClient.update({ resourceType: 'Patient', searchParams: {
+          identifier: 'urn:1.2.3|152747'}, body });
+
+        expect(response.resourceType).to.equal('OperationOutcome');
+        expect(response.issue[0].diagnostics).to.have.string('_history/2');
+      });
+
       it('throws an error for a missing resource', async function () {
         nock(this.baseUrl)
           .matchHeader('accept', 'application/fhir+json')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -554,6 +554,7 @@ export default class Client {
    * @param params.resourceType - The resource type (e.g. "Patient",
    *   "Observation").
    * @param params.id - The FHIR id for the resource.
+   * @param params.searchParams - For a conditional update the searchParams are specified instead of the id, see https://www.hl7.org/fhir/http.html#cond-update
    * @param params.body - The resource to be updated.
    * @param [params.headers] - DEPRECATED Optional custom headers to
    *   add to the request
@@ -564,7 +565,8 @@ export default class Client {
    */
   update<T extends FhirResource>(params: {
     resourceType: ResourceType;
-    id: string;
+    id?: string;
+    searchParams?: SearchParams;
     body: T;
     headers?: HeadersInit;
     options?: RequestInit;


### PR DESCRIPTION
This PR add's support [for conditional update](https://www.hl7.org/fhir/http.html#cond-update), instead of providing the id, searchParameters can be provided. A test case illustrate behaviour.