### PR TITLE
Conditionally import cross-fetch with polyfill - Issue #197

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ DEBUG environment variable, or use `fhir-kit-client:*` to enable both.
 $ DEBUG=fhir-kit-client:* node smart-launch.js
 ```
 
+## Disabling Fetch Polyfill
+
+The optional polyfill in the cross-fetch package can be disabled by setting the environmnt variable FETCH_POLYFILL=disable.
+
 ## Contributing
 
 FHIRKit Client is an open source Node.js FHIR client library that welcomes

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -1,6 +1,12 @@
+/* eslint-disable global-require */
 /* global Request, Headers */
 require('es6-promise').polyfill();
-require('cross-fetch/polyfill');
+
+if (process.env.FETCH_POLYFILL && process.env.FETCH_POLYFILL === 'disable') {
+  require('cross-fetch');
+} else {
+  require('cross-fetch/polyfill');
+}
 
 const { logRequestError, logRequestInfo, logResponseInfo } = require('./logging');
 


### PR DESCRIPTION
Allow developers to conditionally import the optional polyfill with the cross-fetch package to address issue 197 https://github.com/Vermonster/fhir-kit-client/issues/197

It is unclear if the entire package cross-fetch with ponyfill caused the issue or the use of polyfill alone, but we could consider testing with disabled polyfill first. The polyfill is only applied in the absence of global fetch. 

