### PR TITLE
fix: await requestSigner

### DIFF
--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -71,7 +71,7 @@ export class HttpClient {
   private baseUrlValue: string;
   customHeaders: Record<string, string>;
   private readonly baseRequestOptions: Record<string, unknown>;
-  private readonly requestSigner?: (url: string, options: RequestInit) => void;
+  private readonly requestSigner?: (url: string, options: RequestInit) => void | Promise<void>;
   private authHeader: Record<string, string> = {};
   /** Keepalive agents keyed by base URL, reused across requests on this instance. */
   private readonly agentCache = new Map<string, AgentOptions>();
@@ -85,7 +85,7 @@ export class HttpClient {
     baseUrl: string;
     customHeaders?: Record<string, string>;
     requestOptions?: Record<string, unknown>;
-    requestSigner?: (url: string, options: RequestInit) => void;
+    requestSigner?: (url: string, options: RequestInit) => void | Promise<void>;
   }) {
     this.baseUrlValue = '';
     this.baseUrl = baseUrl;
@@ -142,7 +142,7 @@ export class HttpClient {
     return `${this.baseUrl}/${url}`;
   }
 
-  private buildRequest(method: string, url: string, options: RequestOptions, body?: unknown): Request {
+  private async buildRequest(method: string, url: string, options: RequestOptions, body?: unknown): Promise<Request> {
     const requestInit: RequestInit = {
       ...(this.baseRequestOptions as RequestInit),
       method,
@@ -155,7 +155,7 @@ export class HttpClient {
     if (options.signal) requestInit.signal = normalizeSignal(options.signal);
 
     if (this.requestSigner) {
-      this.requestSigner(url, requestInit);
+      await this.requestSigner(url, requestInit);
     }
 
     return new Request(url, requestInit);
@@ -168,7 +168,7 @@ export class HttpClient {
     body?: unknown,
   ): Promise<FhirResource> {
     const url = this.expandUrl(requestUrl);
-    const req = this.buildRequest(method, url, options, body);
+    const req = await this.buildRequest(method, url, options, body);
     logRequestInfo(method, url, req.headers);
 
     const response = await fetch(req);

--- a/test/request-signer.test.ts
+++ b/test/request-signer.test.ts
@@ -32,6 +32,28 @@ const requestSigner = (_url: string, requestOptions: RequestInit): void => {
   });
 };
 
+const asyncRequestSigner = async (_url: string, requestOptions: RequestInit): Promise<void> => {
+  await Promise.resolve();
+  (requestOptions.headers as Headers).set('X-Async-Token', 'async-value');
+};
+
+describe('Client with async request signer', () => {
+  it('awaits an async requestSigner before sending the request', async () => {
+    const capturedHeaders: Record<string, string | null> = {};
+    server.use(
+      http.get(`${BASE_URL}/Patient/123`, ({ request }) => {
+        capturedHeaders['X-Async-Token'] = request.headers.get('x-async-token');
+        return HttpResponse.json(readFixture('patient.json'));
+      }),
+    );
+
+    const client = new Client({ baseUrl: BASE_URL, requestSigner: asyncRequestSigner });
+    await client.request('Patient/123');
+
+    expect(capturedHeaders['X-Async-Token']).toBe('async-value');
+  });
+});
+
 describe('Client with request signer', () => {
   let fhirClient: Client;
 


### PR DESCRIPTION
The README documents an async requestSigner (see the AWS signing example), but the HTTP client called it without await, so any mutations made after an async boundary were silently lost and requests went out unsigned.

Changes:
  - buildRequest is now async and awaits the signer
  - requestSigner type widened to void | Promise<void>: fully backwards
  compatible
  - Test added to cover the async case