### PR TITLE
fix: allow per-request override of keepalive and other fetch options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### Unreleased
+
+**Bug Fixes**
+
+- Per-request `fetch` options (e.g. `keepalive`, `redirect`, `mode`) are now
+  forwarded to the underlying `RequestInit`, allowing callers to override the
+  library defaults on a single call. Previously `keepalive: true` was hardcoded
+  after `baseRequestOptions`, making large request bodies (>64 KiB) fail with
+  `TypeError: failed to fetch` because the Fetch spec caps `keepalive`
+  request bodies at 64 KiB. Reported in [#215](https://github.com/Vermonster/fhir-kit-client/issues/215).
+
 ### 2.0.2
 
 **Bug Fixes**

--- a/README.md
+++ b/README.md
@@ -203,6 +203,22 @@ client.bearerToken = newToken;
 client.customHeaders = { 'X-Tenant': 'new-tenant' };
 ```
 
+#### Per-request `fetch` options
+
+Every read/write/search method accepts an optional `options` object that is
+forwarded to the underlying `RequestInit`. This lets you override library
+defaults on a single call — most notably `keepalive`, which defaults to `true`
+so in-flight requests survive page unload. Because the Fetch spec caps
+`keepalive` request bodies at 64 KiB, large Bundles must opt out:
+
+```ts
+// Send a large transaction Bundle without keepalive
+await client.transaction({ body: bundle, options: { keepalive: false } });
+```
+
+Other `RequestInit` fields (`redirect`, `mode`, `credentials`, etc.) are
+forwarded the same way.
+
 ### Read
 
 ```ts

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -143,6 +143,8 @@ export class HttpClient {
   }
 
   private async buildRequest(method: string, url: string, options: RequestOptions, body?: unknown): Promise<Request> {
+    const { postSearch: _postSearch, headers: _headers, signal: _signal, ...passthrough } = options;
+
     const requestInit: RequestInit = {
       ...(this.baseRequestOptions as RequestInit),
       method,
@@ -150,6 +152,7 @@ export class HttpClient {
       headers: new Headers(this.mergeHeaders(options.headers)),
       keepalive: true,
       ...this.buildAgent(),
+      ...passthrough,
     };
 
     if (options.signal) requestInit.signal = normalizeSignal(options.signal);

--- a/test/http-client.test.ts
+++ b/test/http-client.test.ts
@@ -1,5 +1,8 @@
+import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import { HttpClient } from '../src/http-client.js';
+import { REQUEST_KEY } from '../src/types.js';
+import { server } from './setup.js';
 
 const makeClient = (baseUrl: string) => new HttpClient({ baseUrl });
 
@@ -34,6 +37,26 @@ describe('HttpClient', () => {
     it('returns baseUrl with a separator for an empty path', () => {
       const client = makeClient('https://example.com/fhir');
       expect(client.expandUrl('')).toBe('https://example.com/fhir/');
+    });
+  });
+
+  describe('#request keepalive', () => {
+    const BASE_URL = 'https://example.com';
+
+    it('defaults to keepalive: true', async () => {
+      server.use(http.get(`${BASE_URL}/Basic/1`, () => HttpResponse.json({ resourceType: 'Basic', id: '1' })));
+      const client = makeClient(BASE_URL);
+      const response = await client.get('Basic/1');
+      const request = (response as unknown as Record<string, unknown>)[REQUEST_KEY] as Request;
+      expect(request.keepalive).toBe(true);
+    });
+
+    it('allows overriding keepalive to false per-request', async () => {
+      server.use(http.get(`${BASE_URL}/Basic/1`, () => HttpResponse.json({ resourceType: 'Basic', id: '1' })));
+      const client = makeClient(BASE_URL);
+      const response = await client.get('Basic/1', { keepalive: false });
+      const request = (response as unknown as Record<string, unknown>)[REQUEST_KEY] as Request;
+      expect(request.keepalive).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #215.

`RequestOptions` fields passed to read/write/search methods (e.g. `keepalive`, `redirect`, `mode`) were being dropped before reaching the `Request` constructor, and `keepalive: true` was hardcoded after `baseRequestOptions` — so callers could not override it on a per-request basis.

Because the Fetch spec caps `keepalive` request bodies at 64 KiB, large Bundles failed with `TypeError: failed to fetch` (request stuck as `pending`, never reaching the server). The only workaround was to misuse `requestSigner` to mutate `requestInit.keepalive`.

## Change

`HttpClient.buildRequest` now destructures the reserved keys (`headers`, `signal`, `postSearch`) and spreads the remaining passthrough options **after** the library defaults, so any `RequestInit` field a caller passes wins:

```ts
// Send a large transaction Bundle without keepalive
await client.transaction({ body: bundle, options: { keepalive: false } });
```

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm test` — 178 passing (2 new tests covering default `keepalive: true` and per-request `keepalive: false`)
- CHANGELOG and README updated